### PR TITLE
:beatle: Fix migration command in doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ docker-compose exec app php artisan make:migration <file name> -create=<table 
 
 ```config
 $ docker-compose exec app bash
-> php artisan make:migration <file name> -create=<table name>
+> php artisan make:migration <file name> --create=<table name>
 ```
 
 `/database/migrations` ディレクトリ内に migrate ファイルが作成されるので、テーブルのカラムを設定する


### PR DESCRIPTION
ドキュメントの migration コマンドを修正しました


> ```
> $ docker-compose exec app php artisan make:migration docker_laravel -create=recipes
> The "-c" option does not exist.
> ```
> create の前にハイフンが一本足りないかもです！
> cf. #1 